### PR TITLE
Fix build issue in Docker container caused by new version of 'altair'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib==3.5.0
 scikit-learn==1.0.2
 ipykernel==6.16.0
 streamlit==1.18.1
+altair<5


### PR DESCRIPTION
The recent update to 'altair' version 5 introduced compatibility issues, resulting in a build failure within the Docker container. This commit resolves the problem by downgrading 'altair' to the previous version in the requirements.txt file, ensuring a successful build in the container.